### PR TITLE
Set the google cache path to the Laravel storage dir

### DIFF
--- a/src/LaravelAnalyticsServiceProvider.php
+++ b/src/LaravelAnalyticsServiceProvider.php
@@ -75,6 +75,8 @@ class LaravelAnalyticsServiceProvider extends ServiceProvider
                 'use_objects' => true,
             ]
         );
+        
+        $client->setClassConfig('Google_Cache_File', 'directory', storage_path('app/google_cache'));
 
         $client->setAccessType('offline');
 


### PR DESCRIPTION
Keeps temporary files inside the storage directory. Useful for servers with open_basedir restrictions.