### PR TITLE
Setter for siteId in LaravelAnalytics.php

### DIFF
--- a/src/LaravelAnalytics.php
+++ b/src/LaravelAnalytics.php
@@ -307,6 +307,20 @@ class LaravelAnalytics
     {
         return $this->siteId != '';
     }
+    
+    /**
+     * Set the siteId
+     *
+     * @param string $siteId
+
+     * @return $this
+     */
+    public function setSiteId($siteId)
+    {
+        $this->siteId = $siteId;
+
+        return $this;
+    }
 
     /**
      * Returns an array with the current date and the date minus the number of days specified.


### PR DESCRIPTION
In my current project i needed the ability to set the siteId in runtime for multiple domain support. This PR add's a simple setter for the property `$siteId`

Example:

    \LaravelAnalytics::setSiteId('ga:123456')->getActiveUsers();