### PR TITLE
Configurable cache path

### DIFF
--- a/src/AnalyticsClientFactory.php
+++ b/src/AnalyticsClientFactory.php
@@ -21,6 +21,8 @@ class AnalyticsClientFactory
     {
         $client = new Google_Client();
 
+        $client->setClassConfig('Google_Cache_File', 'directory', $config['cache_location']);
+
         $credentials = $client->loadServiceAccountJson(
             $config['service_account_credentials_json'],
             'https://www.googleapis.com/auth/analytics.readonly'

--- a/src/config/laravel-analytics.php
+++ b/src/config/laravel-analytics.php
@@ -19,4 +19,9 @@ return [
      */
     'cache_lifetime_in_minutes' => 60 * 24,
 
+    /*
+     * The storage location for the Google API cache
+     */
+    'cache_location' =>  storage_path('app/laravel-google-analytics/google-cache/'),
+
 ];


### PR DESCRIPTION
Many people describe problems just falling back on Googles file cache: 
- http://stackoverflow.com/questions/28562220/path-issue-on-laravel-google-analytics-package
- http://stackoverflow.com/questions/27088858/google-api-client-php-mkdirpermission-denied
- http://stackoverflow.com/questions/5246114/php-mkdir-permission-denied-problem

This should fix this issue, by overriding the cache storage location and placing it into the ```storage/``` directory. 

Sorry, not sure how best to test this. 