### PR TITLE
Add cache_location to README.md example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ return [
      * If you set this to zero, the responses won't be cached at all.
      */
     'cache_lifetime_in_minutes' => 60 * 24,
+    
+    /*
+     * The directory where the underlying Google_Client will store it's cache files.
+     */
+    'cache_location' => storage_path('app/laravel-google-analytics/google-cache/'),
 ];
 
 ```


### PR DESCRIPTION
Hello just saw this was missing in the read me when investigating the new config variable.

Could this be considered as a breaking change? 

Because config's published before 2.2 wont have this variable and it might cause an "ErrorException: Undefined index: cache_location". 

Should there be an internal fallback added?