### PR TITLE
Merge default config to make publishing of config optional.

### DIFF
--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -22,7 +22,7 @@ class AnalyticsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__ . '/config/analytics.php', 'analytics');
+        $this->mergeConfigFrom(__DIR__.'/config/analytics.php', 'analytics');
 
         $analyticsConfig = config('analytics');
 

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -22,6 +22,8 @@ class AnalyticsServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__ . '/config/analytics.php', 'analytics');
+
         $analyticsConfig = config('analytics');
 
         $this->app->bind(AnalyticsClient::class, function () use ($analyticsConfig) {


### PR DESCRIPTION
The PR will:
- Fix InvalidConfiguration error.
> There was no view id specified. You must provide a valid view id to execute querys on Google Analytics

- Allow us to just add `ANALYTICS_VIEW_ID=` on our env without the published configuration.
