### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,59 +1,58 @@
 {
-  "name": "spatie/laravel-analytics",
-  "description": "A Laravel 5 package to retrieve Google Analytics data.",
-  "keywords": [
-    "spatie",
-    "google",
-    "analytics",
-    "retrieve",
-    "reports",
-    "laravel"
-  ],
-  "homepage": "https://github.com/spatie/laravel-analytics",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Freek Van der Herten",
-      "email": "freek@spatie.be",
-      "homepage": "https://murze.be",
-      "role": "Developer"
+    "name": "spatie/laravel-analytics",
+    "description": "A Laravel 5 package to retrieve Google Analytics data.",
+    "keywords": [
+        "spatie",
+        "google",
+        "analytics",
+        "retrieve",
+        "reports",
+        "laravel"
+    ],
+    "homepage": "https://github.com/spatie/laravel-analytics",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Freek Van der Herten",
+            "email": "freek@spatie.be",
+            "homepage": "https://murze.be",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": "^7.0",
+        "google/apiclient": "^2.0",
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.4.0|~5.5.x-dev",
+        "madewithlove/illuminate-psr-cache-bridge": "^1.0",
+        "nesbot/carbon": "^1.21"
+    },
+    "require-dev": {
+        "mockery/mockery": "^0.9.5",
+        "orchestra/testbench": "~3.4.6|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Spatie\\Analytics\\": "src"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\Analytics\\AnalyticsServiceProvider"
+            ],
+            "aliases": {
+                "Analytics": "Spatie\\Analytics\\AnalyticsFacade"
+            }
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Spatie\\Analytics\\Tests\\": "tests"
+        }
+    },
+    "config": {
+        "sort-packages": true
     }
-  ],
-  "require": {
-    "php" : "^7.0",
-    "google/apiclient" : "^2.0",
-    "illuminate/contracts": "~5.4.0",
-    "illuminate/support": "~5.4.0",
-    "madewithlove/illuminate-psr-cache-bridge": "^1.0",
-    "nesbot/carbon": "^1.21"
-
-  },
-  "require-dev": {
-    "mockery/mockery": "^0.9.5",
-    "orchestra/testbench" : "~3.4.6",
-    "phpunit/phpunit" : "^6.1"
-  },
-  "autoload": {
-    "psr-4": {
-      "Spatie\\Analytics\\": "src"
-    }
-  },
-  "extra":{
-    "laravel":{
-      "providers":[
-        "Spatie\\Analytics\\AnalyticsServiceProvider"
-      ],
-      "aliases":{
-        "Analytics": "Spatie\\Analytics\\AnalyticsFacade"
-      }
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Spatie\\Analytics\\Tests\\": "tests"
-    }
-  },
-  "config": {
-    "sort-packages": true
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     "require": {
         "php": "^7.0",
         "google/apiclient": "^2.0",
-        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.4.0|~5.5.x-dev",
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "madewithlove/illuminate-psr-cache-bridge": "^1.0",
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "orchestra/testbench": "~3.4.6|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.6|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -56,3 +56,4 @@
         "sort-packages": true
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-analytics/phpunit.xml

.........                                                           9 / 9 (100%)

Time: 692 ms, Memory: 12.00MB

OK (9 tests, 24 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments