### PR TITLE
Add months and years periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,23 @@ You'll need the `View ID` displayed there.
 When the installation is done you can easily retrieve Analytics data. Nearly all methods will return an `Illuminate\Support\Collection`-instance.
 
 
-Here is an example to retrieve visitors and pageview data for the current day and the last seven days.
+Here are a few examples using periods 
 ```php
+//retrieve visitors and pageview data for the current day and the last seven days
 $analyticsData = Analytics::fetchVisitorsAndPageViews(Period::days(7));
+
+//retrieve visitors and pageviews since the first day of 6 months ago
+$analyticsData = Analytics::fetchVisitorsAndPageViews(Period::months(6));
+
+//retrieve sessions and pageviews with yearMonth dimension since the first day of current year
+$analyticsData = Analytics::performQuery(
+    Period::years(0),
+    'ga:sessions',
+    [
+        'metrics' => 'ga:sessions, ga:pageviews',
+        'dimensions' => 'ga:yearMonth'
+    ]
+);
 ```
 
 `$analyticsData` is a `Collection` in which each item is an array that holds keys `date`, `visitors` and `pageViews`

--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ Here are a few examples using periods
 //retrieve visitors and pageview data for the current day and the last seven days
 $analyticsData = Analytics::fetchVisitorsAndPageViews(Period::days(7));
 
-//retrieve visitors and pageviews since the first day of 6 months ago
+//retrieve visitors and pageviews since the 6 months ago
 $analyticsData = Analytics::fetchVisitorsAndPageViews(Period::months(6));
 
-//retrieve sessions and pageviews with yearMonth dimension since the first day of current year
+//retrieve sessions and pageviews with yearMonth dimension since 1 year ago 
 $analyticsData = Analytics::performQuery(
-    Period::years(0),
+    Period::years(1),
     'ga:sessions',
     [
         'metrics' => 'ga:sessions, ga:pageviews',

--- a/src/Period.php
+++ b/src/Period.php
@@ -32,7 +32,7 @@ class Period
     {
         $endDate = Carbon::today();
 
-        $startDate = Carbon::today()->subMonth($numberOfMonths)->startOfMonth();
+        $startDate = Carbon::today()->subMonths($numberOfMonths)->startOfMonth();
 
         return new static($startDate, $endDate);
     }
@@ -41,7 +41,7 @@ class Period
     {
         $endDate = Carbon::today();
 
-        $startDate = Carbon::today()->subYear($numberOfYears)->startOfYear();
+        $startDate = Carbon::today()->subYears($numberOfYears)->startOfYear();
 
         return new static($startDate, $endDate);
     }

--- a/src/Period.php
+++ b/src/Period.php
@@ -32,7 +32,7 @@ class Period
     {
         $endDate = Carbon::today();
 
-        $startDate = Carbon::today()->subMonths($numberOfMonths)->startOfMonth();
+        $startDate = Carbon::today()->subMonths($numberOfMonths)->startOfDay();
 
         return new static($startDate, $endDate);
     }
@@ -41,7 +41,7 @@ class Period
     {
         $endDate = Carbon::today();
 
-        $startDate = Carbon::today()->subYears($numberOfYears)->startOfYear();
+        $startDate = Carbon::today()->subYears($numberOfYears)->startOfDay();
 
         return new static($startDate, $endDate);
     }

--- a/src/Period.php
+++ b/src/Period.php
@@ -28,6 +28,24 @@ class Period
         return new static($startDate, $endDate);
     }
 
+    public static function months(int $numberOfMonths): Period
+    {
+        $endDate = Carbon::today();
+
+        $startDate = Carbon::today()->subMonth($numberOfMonths)->startOfMonth();
+
+        return new static($startDate, $endDate);
+    }
+
+    public static function years(int $numberOfYears): Period
+    {
+        $endDate = Carbon::today();
+
+        $startDate = Carbon::today()->subYear($numberOfYears)->startOfYear();
+
+        return new static($startDate, $endDate);
+    }
+
     public function __construct(DateTime $startDate, DateTime $endDate)
     {
         if ($startDate > $endDate) {

--- a/tests/Unit/PeriodTest.php
+++ b/tests/Unit/PeriodTest.php
@@ -21,6 +21,28 @@ class PeriodTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_period_for_a_given_amount_of_months()
+    {
+        Carbon::setTestNow(Carbon::create(2016, 1, 1));
+
+        $period = Period::months(10);
+
+        $this->assertSame('2015-03-01', $period->startDate->format('Y-m-d'));
+        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
+    }
+
+    /** @test */
+    public function it_can_create_a_period_for_a_given_amount_of_years()
+    {
+        Carbon::setTestNow(Carbon::create(2016, 1, 1));
+
+        $period = Period::years(2);
+
+        $this->assertSame('2014-01-01', $period->startDate->format('Y-m-d'));
+        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
+    }
+
+    /** @test */
     public function it_provides_a_create_method()
     {
         $startDate = Carbon::create(2015, 12, 22);

--- a/tests/Unit/PeriodTest.php
+++ b/tests/Unit/PeriodTest.php
@@ -23,23 +23,23 @@ class PeriodTest extends TestCase
     /** @test */
     public function it_can_create_a_period_for_a_given_amount_of_months()
     {
-        Carbon::setTestNow(Carbon::create(2016, 1, 1));
+        Carbon::setTestNow(Carbon::create(2016, 1, 10));
 
         $period = Period::months(10);
 
-        $this->assertSame('2015-03-01', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
+        $this->assertSame('2015-03-10', $period->startDate->format('Y-m-d'));
+        $this->assertSame('2016-01-10', $period->endDate->format('Y-m-d'));
     }
 
     /** @test */
     public function it_can_create_a_period_for_a_given_amount_of_years()
     {
-        Carbon::setTestNow(Carbon::create(2016, 1, 1));
+        Carbon::setTestNow(Carbon::create(2016, 1, 12));
 
         $period = Period::years(2);
 
-        $this->assertSame('2014-01-01', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
+        $this->assertSame('2014-01-12', $period->startDate->format('Y-m-d'));
+        $this->assertSame('2016-01-12', $period->endDate->format('Y-m-d'));
     }
 
     /** @test */


### PR DESCRIPTION
To help process query in the last x months/years starting from the first day of selected period.

Why start from the first day of the month/year?
Because this is how we use most of the times. Especially when we use 'ga:yearMonth' dimensions, people wouldn't want to miss some part of the month/year, because they are querying in the middle of the month/year today.

Thank you