### PR TITLE
Fixes #236 - Allows dynamic modification of config

### DIFF
--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -24,13 +24,16 @@ class AnalyticsServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/analytics.php', 'analytics');
 
-        $analyticsConfig = config('analytics');
 
-        $this->app->bind(AnalyticsClient::class, function () use ($analyticsConfig) {
+        $this->app->bind(AnalyticsClient::class, function () {
+            $analyticsConfig = config('analytics');
+
             return AnalyticsClientFactory::createForConfig($analyticsConfig);
         });
 
-        $this->app->bind(Analytics::class, function () use ($analyticsConfig) {
+        $this->app->bind(Analytics::class, function () {
+            $analyticsConfig = config('analytics');
+
             $this->guardAgainstInvalidConfiguration($analyticsConfig);
 
             $client = app(AnalyticsClient::class);


### PR DESCRIPTION
This addresses the issue mentioned in https://github.com/spatie/laravel-analytics/issues/236

It makes sure when the class is instantiated  it uses a fresh up to date version of the analytics config rather than a version which was cached at boot time.

it allows the config to be changed by various things such as middleware or individual users dashboards.