### PR TITLE
Accept credentials as array too

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ return [
 
     /*
      * Path to the client secret json file. Take a look at the README of this package
-     * to learn how to get this file.
+     * to learn how to get this file. You can also pass the credentials as an array 
+     * instead of a file path.
      */
     'service_account_credentials_json' => storage_path('app/analytics/service-account-credentials.json'),
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
 
   },
   "require-dev": {
+    "league/flysystem": ">=1.0.8",
     "mockery/mockery": "^1.0",
     "orchestra/testbench" : "~3.4.6|~3.5.0|~3.6.0",
     "phpunit/phpunit" : "^6.1|^7.0"

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -9,7 +9,8 @@ return [
 
     /*
      * Path to the client secret json file. Take a look at the README of this package
-     * to learn how to get this file.
+     * to learn how to get this file. You can also pass the credentials as an array
+     * instead of a file path.
      */
     'service_account_credentials_json' => storage_path('app/analytics/service-account-credentials.json'),
 

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -24,7 +24,6 @@ class AnalyticsServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/analytics.php', 'analytics');
 
-
         $this->app->bind(AnalyticsClient::class, function () {
             $analyticsConfig = config('analytics');
 
@@ -48,6 +47,10 @@ class AnalyticsServiceProvider extends ServiceProvider
     {
         if (empty($analyticsConfig['view_id'])) {
             throw InvalidConfiguration::viewIdNotSpecified();
+        }
+
+        if (is_array($analyticsConfig['service_account_credentials_json'])) {
+            return;
         }
 
         if (! file_exists($analyticsConfig['service_account_credentials_json'])) {

--- a/src/Period.php
+++ b/src/Period.php
@@ -14,12 +14,12 @@ class Period
     /** @var \DateTime */
     public $endDate;
 
-    public static function create(DateTime $startDate, $endDate): Period
+    public static function create(DateTime $startDate, $endDate): self
     {
         return new static($startDate, $endDate);
     }
 
-    public static function days(int $numberOfDays): Period
+    public static function days(int $numberOfDays): self
     {
         $endDate = Carbon::today();
 
@@ -28,7 +28,7 @@ class Period
         return new static($startDate, $endDate);
     }
 
-    public static function months(int $numberOfMonths): Period
+    public static function months(int $numberOfMonths): self
     {
         $endDate = Carbon::today();
 
@@ -37,7 +37,7 @@ class Period
         return new static($startDate, $endDate);
     }
 
-    public static function years(int $numberOfYears): Period
+    public static function years(int $numberOfYears): self
     {
         $endDate = Carbon::today();
 

--- a/tests/Integration/AnalyticsServiceProviderTest.php
+++ b/tests/Integration/AnalyticsServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Analytics\Tests\Integration;
 
+use Storage;
 use Analytics;
 use Carbon\Carbon;
 use Spatie\Analytics\Exceptions\InvalidConfiguration;
@@ -11,10 +12,72 @@ class AnalyticsServiceProviderTest extends TestCase
     /** @test */
     public function it_will_throw_an_exception_if_the_view_id_is_not_set()
     {
-        $this->app['config']->set('laravel-analytics.view_id', '');
+        $this->app['config']->set('analytics.view_id', '');
 
         $this->expectException(InvalidConfiguration::class);
 
         Analytics::fetchVisitorsAndPageViews(Carbon::now()->subDay(), Carbon::now());
+    }
+
+    /** @test */
+    public function it_allows_credentials_json_file()
+    {
+        Storage::fake('testing-storage');
+
+        Storage::disk('testing-storage')
+            ->put('test-credentials.json', json_encode($this->get_credentials()));
+
+        $credentials_json_file_path = Storage::disk('testing-storage')
+            ->getDriver()
+            ->getAdapter()
+            ->applyPathPrefix('test-credentials.json');
+
+        $this->app['config']->set('analytics.view_id', '123456');
+
+        $this->app['config']->set('analytics.service_account_credentials_json', $credentials_json_file_path);
+
+        $analytics = $this->app['laravel-analytics'];
+
+        $this->assertInstanceOf(\Spatie\Analytics\Analytics::class, $analytics);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_if_the_credentials_json_does_not_exist()
+    {
+        $this->app['config']->set('analytics.view_id', '123456');
+
+        $this->app['config']->set('analytics.service_account_credentials_json', 'bogus.json');
+
+        $this->expectException(InvalidConfiguration::class);
+
+        Analytics::fetchVisitorsAndPageViews(Carbon::now()->subDay(), Carbon::now());
+    }
+
+    /** @test */
+    public function it_allows_credentials_json_to_be_array()
+    {
+        $this->app['config']->set('analytics.view_id', '123456');
+
+        $this->app['config']->set('analytics.service_account_credentials_json', $this->get_credentials());
+
+        $analytics = $this->app['laravel-analytics'];
+
+        $this->assertInstanceOf(\Spatie\Analytics\Analytics::class, $analytics);
+    }
+
+    protected function get_credentials()
+    {
+        return [
+            'type' => 'service_account',
+            'project_id' => 'bogus-project',
+            'private_key_id' => 'bogus-id',
+            'private_key' => 'bogus-key',
+            'client_email' => 'bogus-user@bogus-app.iam.gserviceaccount.com',
+            'client_id' => 'bogus-id',
+            'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+            'token_uri' => 'https://accounts.google.com/o/oauth2/token',
+            'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+            'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/bogus-ser%40bogus-app.iam.gserviceaccount.com',
+        ];
     }
 }


### PR DESCRIPTION
google-api-php-client's `->setAuthConfig($auth)`  allows both file and array configs. 
This change allows for setting the credential config directly in analytics.php config or through a Config::set() call...

Also, I've added some tests. 

Finally, in the AnalyticsSPTest, there was a config set call with `laravel-analytics.view_id`, I changed this to `analytics.view_id`. 