### PR TITLE
update next page and check the limit, fixes issue #269

### DIFF
--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -67,6 +67,10 @@ class AnalyticsClient
             );
 
             while ($nextLink = $result->getNextLink()) {
+                if (isset($others['max-results']) && count($result->rows) >= $others['max-results']) {
+                    break;
+                }
+
                 $options = [];
 
                 parse_str(substr($nextLink, strpos($nextLink, '?') + 1), $options);
@@ -76,6 +80,8 @@ class AnalyticsClient
                 if ($response->rows) {
                     $result->rows = array_merge($result->rows, $response->rows);
                 }
+
+                $result->nextLink = $response->nextLink;
             }
 
             return $result;


### PR DESCRIPTION
Greetings,

Latest commit on pagination creates issues. 

First it is not updating the next page so that it's creating an infinite loop.

Second, if there exists a next link, the query result is not limiting the total rows using the max results but paginates using the max results. To elaborate, if there are let's say 1000 items whereas the max item count is 20, it will query 50 times.