### PR TITLE
convert $cacheLifeTimeInMinutes in seconds

### DIFF
--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -33,7 +33,7 @@ class AnalyticsClient
      */
     public function setCacheLifeTimeInMinutes(int $cacheLifeTimeInMinutes)
     {
-        $this->cacheLifeTimeInMinutes = $cacheLifeTimeInMinutes;
+        $this->cacheLifeTimeInMinutes = $cacheLifeTimeInMinutes * 60;
 
         return $this;
     }


### PR DESCRIPTION
As of laravel 5.8, cache time is in seconds.
