### PR TITLE
Add the DateTime type to $endDate

### DIFF
--- a/src/Period.php
+++ b/src/Period.php
@@ -14,7 +14,7 @@ class Period
     /** @var \DateTime */
     public $endDate;
 
-    public static function create(DateTime $startDate, $endDate): self
+    public static function create(DateTime $startDate, DateTime $endDate): self
     {
         return new static($startDate, $endDate);
     }


### PR DESCRIPTION
While using the package I found out that the enddate of the create function didn't had a type declared while it also need to be a DateTime.

I know it is a small thing but I thought, easy one to fix.