### PR TITLE
Widened DateTime to DateTimeInterface to allow immutables usage

### DIFF
--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Analytics;
 
-use DateTime;
+use DateTimeInterface;
 use Google_Service_Analytics;
 use Illuminate\Contracts\Cache\Repository;
 
@@ -42,14 +42,14 @@ class AnalyticsClient
      * Query the Google Analytics Service with given parameters.
      *
      * @param string $viewId
-     * @param \DateTime $startDate
-     * @param \DateTime $endDate
+     * @param \DateTimeInterface $startDate
+     * @param \DateTimeInterface $endDate
      * @param string $metrics
      * @param array $others
      *
      * @return array|null
      */
-    public function performQuery(string $viewId, DateTime $startDate, DateTime $endDate, string $metrics, array $others = [])
+    public function performQuery(string $viewId, DateTimeInterface $startDate, DateTimeInterface $endDate, string $metrics, array $others = [])
     {
         $cacheName = $this->determineCacheName(func_get_args());
 

--- a/src/Exceptions/InvalidPeriod.php
+++ b/src/Exceptions/InvalidPeriod.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\Analytics\Exceptions;
 
-use DateTime;
+use DateTimeInterface;
 use Exception;
 
 class InvalidPeriod extends Exception
 {
-    public static function startDateCannotBeAfterEndDate(DateTime $startDate, DateTime $endDate)
+    public static function startDateCannotBeAfterEndDate(DateTimeInterface $startDate, DateTimeInterface $endDate)
     {
         return new static("Start date `{$startDate->format('Y-m-d')}` cannot be after end date `{$endDate->format('Y-m-d')}`.");
     }

--- a/src/Period.php
+++ b/src/Period.php
@@ -3,18 +3,18 @@
 namespace Spatie\Analytics;
 
 use Carbon\Carbon;
-use DateTime;
+use DateTimeInterface;
 use Spatie\Analytics\Exceptions\InvalidPeriod;
 
 class Period
 {
-    /** @var \DateTime */
+    /** @var \DateTimeInterface */
     public $startDate;
 
-    /** @var \DateTime */
+    /** @var \DateTimeInterface */
     public $endDate;
 
-    public static function create(DateTime $startDate, DateTime $endDate): self
+    public static function create(DateTimeInterface $startDate, DateTimeInterface $endDate): self
     {
         return new static($startDate, $endDate);
     }
@@ -46,7 +46,7 @@ class Period
         return new static($startDate, $endDate);
     }
 
-    public function __construct(DateTime $startDate, DateTime $endDate)
+    public function __construct(DateTimeInterface $startDate, DateTimeInterface $endDate)
     {
         if ($startDate > $endDate) {
             throw InvalidPeriod::startDateCannotBeAfterEndDate($startDate, $endDate);

--- a/tests/Unit/PeriodTest.php
+++ b/tests/Unit/PeriodTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Analytics\Tests;
 
 use Carbon\Carbon;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Spatie\Analytics\Exceptions\InvalidPeriod;
 use Spatie\Analytics\Period;
@@ -47,6 +48,18 @@ class PeriodTest extends TestCase
     {
         $startDate = Carbon::create(2015, 12, 22);
         $endDate = Carbon::create(2016, 1, 1);
+
+        $period = Period::create($startDate, $endDate);
+
+        $this->assertSame('2015-12-22', $period->startDate->format('Y-m-d'));
+        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
+    }
+
+    /** @test */
+    public function it_accepts_datetime_immutable_instances()
+    {
+        $startDate = Carbon::create(2015, 12, 22)->toDateTimeImmutable();
+        $endDate = Carbon::create(2016, 1, 1)->toDateTimeImmutable();
 
         $period = Period::create($startDate, $endDate);
 

--- a/tests/Unit/PeriodTest.php
+++ b/tests/Unit/PeriodTest.php
@@ -58,10 +58,12 @@ class PeriodTest extends TestCase
     /** @test */
     public function it_accepts_datetime_immutable_instances()
     {
-        $startDate = Carbon::create(2015, 12, 22)->toDateTimeImmutable();
-        $endDate = Carbon::create(2016, 1, 1)->toDateTimeImmutable();
+        $startDate = Carbon::create(2015, 12, 22)->toIso8601String();
+        $startDateImmutable= new DateTimeImmutable($startDate);
+        $endDate = Carbon::create(2016, 1, 1)->toIso8601String();
+        $endDateImmutable= new DateTimeImmutable($endDate);
 
-        $period = Period::create($startDate, $endDate);
+        $period = Period::create($startDateImmutable, $endDateImmutable);
 
         $this->assertSame('2015-12-22', $period->startDate->format('Y-m-d'));
         $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));


### PR DESCRIPTION
This PR replaces all mentions of the `\DateTime` class with the [`\DateTimeInterface` interface](https://www.php.net/manual/en/class.datetimeinterface.php), making it possible to create Periods with instances of `\DateTimeImmutable`.  
This is both preferable from a code quality point of view as well as improving compatibility with other libraries.

As the interface simply formalizes the public API of the DateTime classes, this should not have any implications for existing applications.