### PR TITLE
Add PHP 8-only Support (v4)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.3, 7.4, 8.0]
+                php: [8.0]
                 laravel: [8.*, 6.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -19,9 +19,6 @@ jobs:
                         testbench: 5.*
                     -   laravel: 6.*
                         testbench: 4.*
-                exclude:
-                    -   laravel: 8.*
-                        php: 7.2
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,15 +10,13 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.0]
-                laravel: [8.*, 6.*, 7.*]
+                laravel: [8.*, 7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
                         testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Laravel-Analytics will be documented in this file
 
+## 4.0.0 - unreleased
+
+- support PHP 8+
+- drop support for PHP 7.x
+- use PHP 8 syntax where possible
+
 ## 3.11.0 - 2021-03-04
 
 - widened DateTime to DateTimeInterface to allow immutables usage (#390)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation
 
+> For Laravel 6.x, use version 3.x of this package.
+
 > For Laravel 5.8, use version 3.7.0 of this package!
 
 This package can be installed through Composer.

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,11 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "google/apiclient": "^2.0|^2.7",
         "laravel/framework": "^6.0|^7.0|^8.0",
         "nesbot/carbon": "^2.0",
+        "spatie/laravel-package-tools": "^1.6",
         "symfony/cache": "^4.3|^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.0",
         "google/apiclient": "^2.0|^2.7",
-        "laravel/framework": "^6.0|^7.0|^8.0",
+        "laravel/framework": "^7.0|^8.0",
         "nesbot/carbon": "^2.0",
         "spatie/laravel-package-tools": "^1.6",
         "symfony/cache": "^4.3|^5.0"
@@ -30,7 +30,7 @@
     "require-dev": {
         "league/flysystem": ">=1.0.8",
         "mockery/mockery": "^1.4.2",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -11,16 +11,10 @@ class Analytics
 {
     use Macroable;
 
-    /** @var \Spatie\Analytics\AnalyticsClient */
-    protected $client;
+    protected AnalyticsClient $client;
 
-    /** @var string */
-    protected $viewId;
+    protected string $viewId;
 
-    /**
-     * @param \Spatie\Analytics\AnalyticsClient $client
-     * @param string                            $viewId
-     */
     public function __construct(AnalyticsClient $client, string $viewId)
     {
         $this->client = $client;
@@ -28,12 +22,7 @@ class Analytics
         $this->viewId = $viewId;
     }
 
-    /**
-     * @param string $viewId
-     *
-     * @return $this
-     */
-    public function setViewId(string $viewId)
+    public function setViewId(string $viewId): self
     {
         $this->viewId = $viewId;
 
@@ -184,7 +173,7 @@ class Analytics
      *
      * @return array|null
      */
-    public function performQuery(Period $period, string $metrics, array $others = [])
+    public function performQuery(Period $period, string $metrics, array $others = []): array|null
     {
         return $this->client->performQuery(
             $this->viewId,
@@ -195,7 +184,7 @@ class Analytics
         );
     }
 
-    /*
+    /**
      * Get the underlying Google_Service_Analytics object. You can use this
      * to basically call anything on the Google Analytics API.
      */

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -8,20 +8,13 @@ use Illuminate\Contracts\Cache\Repository;
 
 class AnalyticsClient
 {
-    /** @var \Google_Service_Analytics */
-    protected $service;
+    protected int $cacheLifeTimeInMinutes = 0;
 
-    /** @var \Illuminate\Contracts\Cache\Repository */
-    protected $cache;
-
-    /** @var int */
-    protected $cacheLifeTimeInMinutes = 0;
-
-    public function __construct(Google_Service_Analytics $service, Repository $cache)
-    {
-        $this->service = $service;
-
-        $this->cache = $cache;
+    public function __construct(
+        protected Google_Service_Analytics $service,
+        protected Repository $cache,
+    ) {
+        //
     }
 
     /**
@@ -31,7 +24,7 @@ class AnalyticsClient
      *
      * @return self
      */
-    public function setCacheLifeTimeInMinutes(int $cacheLifeTimeInMinutes)
+    public function setCacheLifeTimeInMinutes(int $cacheLifeTimeInMinutes): self
     {
         $this->cacheLifeTimeInMinutes = $cacheLifeTimeInMinutes * 60;
 
@@ -49,7 +42,7 @@ class AnalyticsClient
      *
      * @return array|null
      */
-    public function performQuery(string $viewId, DateTimeInterface $startDate, DateTimeInterface $endDate, string $metrics, array $others = [])
+    public function performQuery(string $viewId, DateTimeInterface $startDate, DateTimeInterface $endDate, string $metrics, array $others = []): array|null
     {
         $cacheName = $this->determineCacheName(func_get_args());
 
@@ -93,7 +86,7 @@ class AnalyticsClient
         return $this->service;
     }
 
-    /*
+    /**
      * Determine the cache name for the set of query properties given.
      */
     protected function determineCacheName(array $properties): string

--- a/src/AnalyticsClientFactory.php
+++ b/src/AnalyticsClientFactory.php
@@ -34,7 +34,7 @@ class AnalyticsClientFactory
         return $client;
     }
 
-    protected static function configureCache(Google_Client $client, $config)
+    protected static function configureCache(Google_Client $client, $config): void
     {
         $config = collect($config);
 

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -2,28 +2,21 @@
 
 namespace Spatie\Analytics;
 
-use Illuminate\Support\ServiceProvider;
 use Spatie\Analytics\Exceptions\InvalidConfiguration;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
 
-class AnalyticsServiceProvider extends ServiceProvider
+class AnalyticsServiceProvider extends PackageServiceProvider
 {
-    /**
-     * Bootstrap the application events.
-     */
-    public function boot()
+    public function configurePackage(Package $package): void
     {
-        $this->publishes([
-            __DIR__.'/../config/analytics.php' => config_path('analytics.php'),
-        ]);
+        $package
+            ->name('laravel-analytics')
+            ->hasConfigFile();
     }
 
-    /**
-     * Register the service provider.
-     */
-    public function register()
+    public function registeringPackage(): void
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/analytics.php', 'analytics');
-
         $this->app->bind(AnalyticsClient::class, function () {
             $analyticsConfig = config('analytics');
 
@@ -43,7 +36,7 @@ class AnalyticsServiceProvider extends ServiceProvider
         $this->app->alias(Analytics::class, 'laravel-analytics');
     }
 
-    protected function guardAgainstInvalidConfiguration(array $analyticsConfig = null)
+    protected function guardAgainstInvalidConfiguration(array $analyticsConfig = null): void
     {
         if (empty($analyticsConfig['view_id'])) {
             throw InvalidConfiguration::viewIdNotSpecified();

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -6,12 +6,12 @@ use Exception;
 
 class InvalidConfiguration extends Exception
 {
-    public static function viewIdNotSpecified()
+    public static function viewIdNotSpecified(): static
     {
         return new static('There was no view ID specified. You must provide a valid view ID to execute queries on Google Analytics.');
     }
 
-    public static function credentialsJsonDoesNotExist(string $path)
+    public static function credentialsJsonDoesNotExist(string $path): static
     {
         return new static("Could not find a credentials file at `{$path}`.");
     }

--- a/src/Exceptions/InvalidPeriod.php
+++ b/src/Exceptions/InvalidPeriod.php
@@ -7,7 +7,7 @@ use Exception;
 
 class InvalidPeriod extends Exception
 {
-    public static function startDateCannotBeAfterEndDate(DateTimeInterface $startDate, DateTimeInterface $endDate)
+    public static function startDateCannotBeAfterEndDate(DateTimeInterface $startDate, DateTimeInterface $endDate): static
     {
         return new static("Start date `{$startDate->format('Y-m-d')}` cannot be after end date `{$endDate->format('Y-m-d')}`.");
     }

--- a/src/Period.php
+++ b/src/Period.php
@@ -8,18 +8,16 @@ use Spatie\Analytics\Exceptions\InvalidPeriod;
 
 class Period
 {
-    /** @var \DateTimeInterface */
-    public $startDate;
+    public \DateTimeInterface $startDate;
 
-    /** @var \DateTimeInterface */
-    public $endDate;
+    public \DateTimeInterface $endDate;
 
     public static function create(DateTimeInterface $startDate, DateTimeInterface $endDate): self
     {
         return new static($startDate, $endDate);
     }
 
-    public static function days(int $numberOfDays): self
+    public static function days(int $numberOfDays): static
     {
         $endDate = Carbon::today();
 
@@ -28,7 +26,7 @@ class Period
         return new static($startDate, $endDate);
     }
 
-    public static function months(int $numberOfMonths): self
+    public static function months(int $numberOfMonths): static
     {
         $endDate = Carbon::today();
 
@@ -37,7 +35,7 @@ class Period
         return new static($startDate, $endDate);
     }
 
-    public static function years(int $numberOfYears): self
+    public static function years(int $numberOfYears): static
     {
         $endDate = Carbon::today();
 


### PR DESCRIPTION
This PR adds a new major version, v4.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- All syntax converted to PHP 8 where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Removes Laravel v6 support.
- Implements spatie/laravel-package-tools.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._