### PR TITLE
Allow "Google_Service_Analytics_GaData" return type  for performQuery methods

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -154,7 +154,7 @@ class Analytics
      * @param string $metrics
      * @param array  $others
      *
-     * @return array|null
+     * @return Google_Service_Analytics_GaData|array|null
      */
     public function performQuery(Period $period, string $metrics, array $others = []): Google_Service_Analytics_GaData | array | null
     {

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -4,6 +4,7 @@ namespace Spatie\Analytics;
 
 use Carbon\Carbon;
 use Google_Service_Analytics;
+use Google_Service_Analytics_GaData;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 
@@ -155,7 +156,7 @@ class Analytics
      *
      * @return array|null
      */
-    public function performQuery(Period $period, string $metrics, array $others = []): array | null
+    public function performQuery(Period $period, string $metrics, array $others = []): Google_Service_Analytics_GaData | array | null
     {
         return $this->client->performQuery(
             $this->viewId,

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -4,6 +4,7 @@ namespace Spatie\Analytics;
 
 use DateTimeInterface;
 use Google_Service_Analytics;
+use Google_Service_Analytics_GaData;
 use Illuminate\Contracts\Cache\Repository;
 
 class AnalyticsClient
@@ -35,7 +36,7 @@ class AnalyticsClient
      *
      * @return array|null
      */
-    public function performQuery(string $viewId, DateTimeInterface $startDate, DateTimeInterface $endDate, string $metrics, array $others = []): array | null
+    public function performQuery(string $viewId, DateTimeInterface $startDate, DateTimeInterface $endDate, string $metrics, array $others = []): Google_Service_Analytics_GaData | array | null
     {
         $cacheName = $this->determineCacheName(func_get_args());
 

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -34,7 +34,7 @@ class AnalyticsClient
      * @param string $metrics
      * @param array $others
      *
-     * @return array|null
+     * @return Google_Service_Analytics_GaData|array|null
      */
     public function performQuery(string $viewId, DateTimeInterface $startDate, DateTimeInterface $endDate, string $metrics, array $others = []): Google_Service_Analytics_GaData | array | null
     {


### PR DESCRIPTION
Fix #398 