### PR TITLE
The Google Analytics object is now serialized for Redis caching.

### DIFF
--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -44,7 +44,9 @@ class AnalyticsClient
             $this->cache->forget($cacheName);
         }
 
-        return $this->cache->remember($cacheName, $this->cacheLifeTimeInMinutes, function () use ($viewId, $startDate, $endDate, $metrics, $others) {
+        $requiresSerialization = $this->cache->getStore() instanceof \Illuminate\Cache\RedisStore;
+		
+        $result = $this->cache->remember($cacheName, $this->cacheLifeTimeInMinutes, function () use ($viewId, $startDate, $endDate, $metrics, $others) {
             $result = $this->service->data_ga->get(
                 "ga:{$viewId}",
                 $startDate->format('Y-m-d'),
@@ -71,8 +73,10 @@ class AnalyticsClient
                 $result->nextLink = $response->nextLink;
             }
 
-            return $result;
+            return $requiresSerialization ? serialize($result) : $result;
         });
+		
+		return $requiresSerialization ? unserialize($result) : $result;
     }
 
     public function getAnalyticsService(): Google_Service_Analytics

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -46,7 +46,7 @@ class AnalyticsClient
 
         $requiresSerialization = $this->cache->getStore() instanceof \Illuminate\Cache\RedisStore;
 		
-        $result = $this->cache->remember($cacheName, $this->cacheLifeTimeInMinutes, function () use ($viewId, $startDate, $endDate, $metrics, $others) {
+        $result = $this->cache->remember($cacheName, $this->cacheLifeTimeInMinutes, function () use ($viewId, $startDate, $endDate, $metrics, $others, $requiresSerialization) {
             $result = $this->service->data_ga->get(
                 "ga:{$viewId}",
                 $startDate->format('Y-m-d'),


### PR DESCRIPTION
Previously it would return string "Object" on subsequent page loads because Redis does not serialize PHP objects by default.