### PR TITLE
Fix the Alias Errors Following the Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,30 @@ Using this package you can easily retrieve data from Google Analytics.
 Here are a few examples of the provided methods:
 
 ```php
-use Analytics;
+use Spatie\Analytics\Analytics;
 use Spatie\Analytics\Period;
 
-//fetch the most visited pages for today and the past week
-Analytics::fetchMostVisitedPages(Period::days(7));
+class ViewController extends Controller
+{
+    protected $analytics = null;
 
-//fetch visitors and page views for the past week
-Analytics::fetchVisitorsAndPageViews(Period::days(7));
+    public function __construct(Analytics $analytics)
+    {
+        $this->analytics = $analytics;
+    }
+
+    public function index()
+    {
+        //fetch the most visited pages for today and the past week
+        $mostViewed = $this->analytics->fetchMostVisitedPages(Period::days(7));
+
+        //fetch visitors and page views for the past week
+        $visitors = $this->analytics->fetchVisitorsAndPageViews(Period::days(7));
+        
+        // process and return the data to the view 
+        ...
+    }
+}
 ```
 
 Most methods will return an `\Illuminate\Support\Collection` object containing the results.

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Analytics;
 
+use Illuminate\Foundation\AliasLoader;
 use Spatie\Analytics\Exceptions\InvalidConfiguration;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -34,6 +35,10 @@ class AnalyticsServiceProvider extends PackageServiceProvider
         });
 
         $this->app->alias(Analytics::class, 'laravel-analytics');
+        
+        // load the `Analytics` singleton instance into the app alias list
+        $loader = AliasLoader::getInstance();
+        $loader->alias('Analytics', AnalyticsFacade::class);
     }
 
     protected function guardAgainstInvalidConfiguration(array $analyticsConfig = null): void


### PR DESCRIPTION
A few previous issues (e.g., #316, #335, etc.) have mentioned various alias-based errors following the examples given on the project page. I have personally encountered similar errors in Laravel 7.x and 8.x. 

It seems that the problem was caused by the fact that registering the package facade using `$this->app-alias(...)` alone is not enough, the package needs to call the `AliasLoader` to load the singleton instance into the app as well. 

This PR will address the issue above by calling the `AliasLoader` when registering the package, which will allow `use Analytics` to find the `Analytics` singleton instance created and maintained by the framework.

In addition, this PR will also update the example code in `README.md` to use dependency injections instead, which is the recommended way to use the singleton instance.
