### PR TITLE
Allow empty view ID

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -158,6 +158,10 @@ class Analytics
      */
     public function performQuery(Period $period, string $metrics, array $others = []): Google_Service_Analytics_GaData | array | null
     {
+        if (empty($this->viewId)) {
+            return null;
+        }
+
         return $this->client->performQuery(
             $this->viewId,
             $period->startDate,

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -38,10 +38,6 @@ class AnalyticsServiceProvider extends PackageServiceProvider
 
     protected function guardAgainstInvalidConfiguration(array $analyticsConfig = null): void
     {
-        if (empty($analyticsConfig['view_id'])) {
-            throw InvalidConfiguration::viewIdNotSpecified();
-        }
-
         if (is_array($analyticsConfig['service_account_credentials_json'])) {
             return;
         }

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -6,11 +6,6 @@ use Exception;
 
 class InvalidConfiguration extends Exception
 {
-    public static function viewIdNotSpecified(): static
-    {
-        return new static('There was no view ID specified. You must provide a valid view ID to execute queries on Google Analytics.');
-    }
-
     public static function credentialsJsonDoesNotExist(string $path): static
     {
         return new static("Could not find a credentials file at `{$path}`.");


### PR DESCRIPTION
Hello!

We have implemented your package in our projects and something we keep stumbling upon is that a view ID is **required** in all cases, even though we're still developing and a view ID is not known yet.

That didn't seem very friendly to me, so I changed that by overriding some of the classes to allow an empty view ID. But since I prefer to *not* override and because I thought that this might be useful for others too, I decided to create a PR for it!

What it simply does is not performing the query when the view ID is empty, without throwing an exception. That way the results are always empty when the view ID is not set, but I think that makes more sense?

Let me know what you think. Hopefully you find my contribution useful!