### PR TITLE
Updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,41 +89,49 @@ return [
 
 The first thing you’ll need to do is to get some credentials to use Google API’s. I’m assuming that you’ve already created a Google account and are signed in. Head over to [Google API’s site](https://console.developers.google.com/apis) and click "Select a project" in the header.
 
-![1](https://spatie.github.io/laravel-analytics/v2/1.jpg)
+![1](https://spatie.github.io/laravel-analytics/v4/1.png)
 
-Next up we must specify which API’s the project may consume. In the list of available API’s click "Google Analytics API". On the next screen click "Enable".
+Next up we must specify which API’s the project may consume. In the list of `API Library` click "Google Analytics API". On the next screen click "Enable".
 
-![2](https://spatie.github.io/laravel-analytics/v2/2.jpg)
+![2](https://spatie.github.io/laravel-analytics/v4/2.png)
 
 Now that you’ve created a project that has access to the Analytics API it’s time to download a file with these credentials. Click "Credentials" in the sidebar. You’ll want to create a "Service account key".
 
-![3](https://spatie.github.io/laravel-analytics/v2/3.jpg)
+![3](https://spatie.github.io/laravel-analytics/v4/3.png)
 
-On the next screen you can give the service account a name. You can name it anything you’d like. In the service account id you’ll see an email address. We’ll use this email address later on in this guide. Select "JSON" as the key type and click "Create" to download the JSON file.
+On the next screen you can give the service account a name. You can name it anything you’d like. In the service account id you’ll see an email address. We’ll use this email address later on in this guide.
 
-![4](https://spatie.github.io/laravel-analytics/v2/4.jpg)
+![4](https://spatie.github.io/laravel-analytics/v4/4.png)
+
+Select "JSON" as the key type and click "Create" to download the JSON file.
+
+![5](https://spatie.github.io/laravel-analytics/v4/5.png)
 
 Save the json inside your Laravel project at the location specified in the `service_account_credentials_json` key of the config file of this package. Because the json file contains potentially sensitive information I don't recommend committing it to your git repository.
 
 ### Granting permissions to your Analytics property
 
-I'm assuming that you've already created a Analytics account on the [Analytics site](https://analytics.google.com/analytics). Go to "User management" in the Admin-section of the property.
+I'm assuming that you've already created a Analytics account on the [Analytics site](https://analytics.google.com/analytics). When setting up your property, click on "Advanced options" and make sure you enable `Universal Analytics`.
 
-![5](https://spatie.github.io/laravel-analytics/v2/5.jpg)
+![6](https://spatie.github.io/laravel-analytics/v4/6.png)
 
-On this screen you can grant access to the email address found in the `client_email` key from the json file you download in the previous step. Read only access is enough.
+Go to "User management" in the Admin-section of the property.
 
-![6](https://spatie.github.io/laravel-analytics/v2/6.jpg)
+![7](https://spatie.github.io/laravel-analytics/v4/7.png)
+
+On this screen you can grant access to the email address found in the `client_email` key from the json file you download in the previous step. Analyst role is enough.
+
+![8](https://spatie.github.io/laravel-analytics/v4/8.png)
 
 ### Getting the view id
 
 The last thing you'll have to do is fill in the `view_id` in the config file. You can get the right value on the [Analytics site](https://analytics.google.com/analytics). Go to "View setting" in the Admin-section of the property.
 
-![7](https://spatie.github.io/laravel-analytics/v2/7.jpg)
+![9](https://spatie.github.io/laravel-analytics/v4/9.png)
 
 You'll need the `View ID` displayed there.
 
-![8](https://spatie.github.io/laravel-analytics/v2/8.jpg)
+![10](https://spatie.github.io/laravel-analytics/v4/10.png)
 
 ## Usage
 


### PR DESCRIPTION
* Google Analytics 4 UI and Google Cloud Platform have changed drastically so this PR updates the instructions of setting up a service account
* There's another PR #447 targeting the `gh-pages` branch to add v4 screenshots as visual aid

Signed-off-by: Salim Djerbouh <caddydz4@gmail.com>