### PR TITLE
update google/apiclient and psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "google/apiclient": "^2.7",
+        "google/apiclient": "^2.12.1",
         "laravel/framework": "^9.0",
         "nesbot/carbon": "^2.0",
         "spatie/laravel-package-tools": "^1.9",


### PR DESCRIPTION
Fix error in Install
google/apiclient[v2.7.0, ..., v2.10.1] require guzzlehttp/psr7 ^1.2 -> found guzzlehttp/psr7[1.2.0, ..., 1.x-dev] but it conflicts with your root composer.json require (^2.2).
update guzzlehttp/psr7 v2