### PR TITLE
Feature: Convert PHPUnit tests to PestPHP

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,4 +40,4 @@ jobs:
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             -   name: Execute tests
-                run: vendor/bin/phpunit
+                run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "league/flysystem": "^2.0|^3.0",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^7.0",
+        "pestphp/pest": "^1.21",
         "phpunit/phpunit": "^9.4"
     },
     "autoload": {

--- a/tests/Integration/AnalyticsServiceProviderTest.php
+++ b/tests/Integration/AnalyticsServiceProviderTest.php
@@ -1,80 +1,64 @@
 <?php
 
-namespace Spatie\Analytics\Tests\Integration;
-
-use Analytics;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Analytics\Exceptions\InvalidConfiguration;
 
-class AnalyticsServiceProviderTest extends TestCase
+uses(\Spatie\Analytics\Tests\Integration\TestCase::class);
+
+it('will_throw_an_exception_if_the_view_id_is_not_set', function () {
+    config()->set('analytics.view_id', '');
+
+    Analytics::fetchVisitorsAndPageViews(Carbon::now()->subDay(), Carbon::now());
+})->throws(InvalidConfiguration::class);
+
+it('allows_credentials_json_file', function () {
+    Storage::fake('testing-storage');
+
+    Storage::disk('testing-storage')
+        ->put('test-credentials.json', json_encode(credentials()));
+
+    $credentialsPath = storage_path('framework/testing/disks/testing-storage/test-credentials.json');
+
+    config()->set('analytics.view_id', '123456');
+
+    config()->set('analytics.service_account_credentials_json', $credentialsPath);
+
+    $analytics = $this->app['laravel-analytics'];
+
+    expect($analytics)->toBeInstanceOf(\Spatie\Analytics\Analytics::class);
+});
+
+it('will_throw_an_exception_if_the_credentials_json_does_not_exist', function () {
+    config()->set('analytics.view_id', '123456');
+
+    config()->set('analytics.service_account_credentials_json', 'bogus.json');
+
+    Analytics::fetchVisitorsAndPageViews(Carbon::now()->subDay(), Carbon::now());
+})->throws(InvalidConfiguration::class);
+
+it('allows_credentials_json_to_be_array', function () {
+    config()->set('analytics.view_id', '123456');
+
+    config()->set('analytics.service_account_credentials_json', credentials());
+
+    $analytics = $this->app['laravel-analytics'];
+
+    expect($analytics)->toBeInstanceOf(\Spatie\Analytics\Analytics::class);
+});
+
+function credentials()
 {
-    /** @test */
-    public function it_will_throw_an_exception_if_the_view_id_is_not_set()
-    {
-        $this->app['config']->set('analytics.view_id', '');
-
-        $this->expectException(InvalidConfiguration::class);
-
-        Analytics::fetchVisitorsAndPageViews(Carbon::now()->subDay(), Carbon::now());
-    }
-
-    /** @test */
-    public function it_allows_credentials_json_file()
-    {
-        Storage::fake('testing-storage');
-
-        Storage::disk('testing-storage')
-            ->put('test-credentials.json', json_encode($this->get_credentials()));
-
-        $credentialsPath = storage_path('framework/testing/disks/testing-storage/test-credentials.json');
-
-        config()->set('analytics.view_id', '123456');
-
-        config()->set('analytics.service_account_credentials_json', $credentialsPath);
-
-        $analytics = $this->app['laravel-analytics'];
-
-        $this->assertInstanceOf(\Spatie\Analytics\Analytics::class, $analytics);
-    }
-
-    /** @test */
-    public function it_will_throw_an_exception_if_the_credentials_json_does_not_exist()
-    {
-        $this->app['config']->set('analytics.view_id', '123456');
-
-        $this->app['config']->set('analytics.service_account_credentials_json', 'bogus.json');
-
-        $this->expectException(InvalidConfiguration::class);
-
-        Analytics::fetchVisitorsAndPageViews(Carbon::now()->subDay(), Carbon::now());
-    }
-
-    /** @test */
-    public function it_allows_credentials_json_to_be_array()
-    {
-        $this->app['config']->set('analytics.view_id', '123456');
-
-        $this->app['config']->set('analytics.service_account_credentials_json', $this->get_credentials());
-
-        $analytics = $this->app['laravel-analytics'];
-
-        $this->assertInstanceOf(\Spatie\Analytics\Analytics::class, $analytics);
-    }
-
-    protected function get_credentials()
-    {
-        return [
-            'type' => 'service_account',
-            'project_id' => 'bogus-project',
-            'private_key_id' => 'bogus-id',
-            'private_key' => 'bogus-key',
-            'client_email' => 'bogus-user@bogus-app.iam.gserviceaccount.com',
-            'client_id' => 'bogus-id',
-            'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
-            'token_uri' => 'https://accounts.google.com/o/oauth2/token',
-            'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
-            'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/bogus-ser%40bogus-app.iam.gserviceaccount.com',
-        ];
-    }
+    return [
+        'type' => 'service_account',
+        'project_id' => 'bogus-project',
+        'private_key_id' => 'bogus-id',
+        'private_key' => 'bogus-key',
+        'client_email' => 'bogus-user@bogus-app.iam.gserviceaccount.com',
+        'client_id' => 'bogus-id',
+        'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+        'token_uri' => 'https://accounts.google.com/o/oauth2/token',
+        'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+        'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/bogus-ser%40bogus-app.iam.gserviceaccount.com',
+    ];
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -8,11 +8,6 @@ use Spatie\Analytics\AnalyticsServiceProvider;
 
 abstract class TestCase extends Orchestra
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * @param \Illuminate\Foundation\Application $app
      *

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+// uses(Tests\TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/tests/Unit/AnalyticsTest.php
+++ b/tests/Unit/AnalyticsTest.php
@@ -1,196 +1,201 @@
 <?php
 
-namespace Spatie\Analytics\Tests;
-
 use Carbon\Carbon;
-use Illuminate\Support\Collection;
-use Mockery;
-use PHPUnit\Framework\TestCase;
-use Spatie\Analytics\Analytics;
-use Spatie\Analytics\AnalyticsClient;
 use Spatie\Analytics\Period;
+use Spatie\Analytics\Analytics;
+use Illuminate\Support\Collection;
+use Spatie\Analytics\AnalyticsClient;
 
-class AnalyticsTest extends TestCase
+beforeEach(function () {
+    $this->analyticsClient = Mockery::mock(AnalyticsClient::class);
+
+    $this->viewId = '1234567';
+
+    $this->analytics = new Analytics($this->analyticsClient, $this->viewId);
+
+    $this->startDate = Carbon::now()->subDays(7);
+
+    $this->endDate = Carbon::now();
+});
+
+afterEach(fn () => Mockery::close());
+
+it('can_fetch_the_visitor_and_page_views', function () {
+    $expectedArguments = [
+        $this->viewId,
+        expectCarbon($this->startDate),
+        expectCarbon($this->endDate),
+        'ga:users,ga:pageviews',
+        ['dimensions' => 'ga:date,ga:pageTitle'],
+    ];
+
+    $this
+        ->analyticsClient
+        ->shouldReceive('performQuery')
+        ->withArgs($expectedArguments)
+        ->once()
+        ->andReturn([
+            'rows' => [['20160101', 'pageTitle', '1', '2']],
+        ]);
+
+    $response = $this
+        ->analytics
+        ->fetchVisitorsAndPageViews(
+            Period::create($this->startDate, $this->endDate)
+        );
+
+    expect($response)->toBeInstanceOf(Collection::class);
+    expect($response->first()['date']->format('Y-m-d'))->toBe('2016-01-01');
+    expect($response->first()['pageTitle'])->toBe('pageTitle');
+    expect($response->first()['visitors'])->toBe(1);
+    expect($response->first()['pageViews'])->toBe(2);
+});
+
+it('can_fetch_the_total_visitor_and_page_views', function () {
+    $expectedArguments = [
+        $this->viewId,
+        expectCarbon($this->startDate),
+        expectCarbon($this->endDate),
+        'ga:users,ga:pageviews',
+        ['dimensions' => 'ga:date'],
+    ];
+
+    $this
+        ->analyticsClient
+        ->shouldReceive('performQuery')
+        ->withArgs($expectedArguments)
+        ->once()
+        ->andReturn([
+            'rows' => [['20160101', '1', '2']],
+        ]);
+
+    $response = $this
+        ->analytics
+        ->fetchTotalVisitorsAndPageViews(
+            Period::create($this->startDate, $this->endDate)
+        );
+
+    expect($response)->toBeInstanceOf(Collection::class);
+    expect($response->first()['date']->format('Y-m-d'))->toBe('2016-01-01');
+    expect($response->first()['visitors'])->toBe(1);
+    expect($response->first()['pageViews'])->toBe(2);
+});
+
+it('can_fetch_the_most_visited_pages', function () {
+    $maxResults = 10;
+
+    $expectedArguments = [
+        $this->viewId,
+        expectCarbon($this->startDate),
+        expectCarbon($this->endDate),
+        'ga:pageviews',
+        [
+            'dimensions' => 'ga:pagePath,ga:pageTitle',
+            'sort' => '-ga:pageviews',
+            'max-results' => $maxResults,
+        ],
+    ];
+
+    $this
+        ->analyticsClient
+        ->shouldReceive('performQuery')
+        ->withArgs($expectedArguments)
+        ->once()
+        ->andReturn([
+            'rows' => [['https://test.com', 'Page title', '123']],
+        ]);
+
+    $response = $this
+        ->analytics
+        ->fetchMostVisitedPages(
+            Period::create($this->startDate, $this->endDate),
+            $maxResults
+        );
+
+    expect($response)->toBeInstanceOf(Collection::class);
+    expect($response->first()['url'])->toBe('https://test.com');
+    expect($response->first()['pageTitle'])->toBe('Page title');
+    expect($response->first()['pageViews'])->toBe(123);
+});
+
+it('can_fetch_the_top_referrers', function () {
+    $maxResults = 10;
+
+    $expectedArguments = [
+        $this->viewId,
+        expectCarbon($this->startDate),
+        expectCarbon($this->endDate),
+        'ga:pageviews',
+        [
+            'dimensions' => 'ga:fullReferrer',
+            'sort' => '-ga:pageviews',
+            'max-results' => $maxResults,
+        ],
+    ];
+
+    $this
+        ->analyticsClient
+        ->shouldReceive('performQuery')
+        ->withArgs($expectedArguments)
+        ->once()
+        ->andReturn([
+            'rows' => [['https://referrer.com', '123']],
+        ]);
+
+    $response = $this
+        ->analytics
+        ->fetchTopReferrers(
+            Period::create($this->startDate, $this->endDate),
+            $maxResults
+        );
+
+    expect($response)->toBeInstanceOf(Collection::class);
+    expect($response->first()['url'])->toBe('https://referrer.com');
+    expect($response->first()['pageViews'])->toBe(123);
+});
+
+it('can_fetch_the_top_browsers', function () {
+    $expectedArguments = [
+        $this->viewId,
+        expectCarbon($this->startDate),
+        expectCarbon($this->endDate),
+        'ga:sessions',
+        ['dimensions' => 'ga:browser', 'sort' => '-ga:sessions'],
+    ];
+
+    $this
+        ->analyticsClient
+        ->shouldReceive('performQuery')
+        ->withArgs($expectedArguments)
+        ->once()
+        ->andReturn([
+            'rows' => [
+                ['Browser 1', '100'],
+                ['Browser 2', '90'],
+                ['Browser 3', '30'],
+                ['Browser 4', '20'],
+                ['Browser 1', '10'],
+            ],
+        ]);
+
+    $response = $this
+        ->analytics
+        ->fetchTopBrowsers(
+            Period::create($this->startDate, $this->endDate),
+            3
+        );
+
+    expect($response)->toBeInstanceOf(Collection::class);
+    expect($response->toArray())->toBe([
+        ['browser' => 'Browser 1', 'sessions' => 100],
+        ['browser' => 'Browser 2', 'sessions' => 90],
+        ['browser' => 'Others', 'sessions' => 60],
+    ]);
+});
+
+function expectCarbon(Carbon $carbon)
 {
-    /** @var \Spatie\Analytics\AnalyticsClient|\Mockery\Mock */
-    protected $analyticsClient;
-
-    /** @var string */
-    protected $viewId;
-
-    /** @var \Spatie\Analytics\Analytics */
-    protected $analytics;
-
-    /** @var \Carbon\Carbon */
-    protected $startDate;
-
-    /** @var \Carbon\Carbon */
-    protected $endDate;
-
-    public function setUp(): void
-    {
-        $this->analyticsClient = Mockery::mock(AnalyticsClient::class);
-
-        $this->viewId = '1234567';
-
-        $this->analytics = new Analytics($this->analyticsClient, $this->viewId);
-
-        $this->startDate = Carbon::now()->subDays(7);
-
-        $this->endDate = Carbon::now();
-    }
-
-    public function tearDown(): void
-    {
-        Mockery::close();
-    }
-
-    /** @test */
-    public function it_can_fetch_the_visitor_and_page_views()
-    {
-        $expectedArguments = [
-            $this->viewId,
-            $this->expectCarbon($this->startDate),
-            $this->expectCarbon($this->endDate),
-            'ga:users,ga:pageviews',
-            ['dimensions' => 'ga:date,ga:pageTitle'],
-        ];
-
-        $this->analyticsClient
-            ->shouldReceive('performQuery')->withArgs($expectedArguments)
-            ->once()
-            ->andReturn([
-                'rows' => [['20160101', 'pageTitle', '1', '2']],
-            ]);
-
-        $response = $this->analytics->fetchVisitorsAndPageViews(Period::create($this->startDate, $this->endDate));
-
-        $this->assertInstanceOf(Collection::class, $response);
-        $this->assertEquals('2016-01-01', $response->first()['date']->format('Y-m-d'));
-        $this->assertEquals('pageTitle', $response->first()['pageTitle']);
-        $this->assertEquals(1, $response->first()['visitors']);
-        $this->assertEquals(2, $response->first()['pageViews']);
-    }
-
-    /** @test */
-    public function it_can_fetch_the_total_visitor_and_page_views()
-    {
-        $expectedArguments = [
-            $this->viewId,
-            $this->expectCarbon($this->startDate),
-            $this->expectCarbon($this->endDate),
-            'ga:users,ga:pageviews',
-            ['dimensions' => 'ga:date'],
-        ];
-
-        $this->analyticsClient
-            ->shouldReceive('performQuery')->withArgs($expectedArguments)
-            ->once()
-            ->andReturn([
-                'rows' => [['20160101', '1', '2']],
-            ]);
-
-        $response = $this->analytics->fetchTotalVisitorsAndPageViews(Period::create($this->startDate, $this->endDate));
-
-        $this->assertInstanceOf(Collection::class, $response);
-        $this->assertEquals('2016-01-01', $response->first()['date']->format('Y-m-d'));
-        $this->assertEquals(1, $response->first()['visitors']);
-        $this->assertEquals(2, $response->first()['pageViews']);
-    }
-
-    /** @test */
-    public function it_can_fetch_the_most_visited_pages()
-    {
-        $maxResults = 10;
-
-        $expectedArguments = [
-            $this->viewId,
-            $this->expectCarbon($this->startDate),
-            $this->expectCarbon($this->endDate),
-            'ga:pageviews',
-            ['dimensions' => 'ga:pagePath,ga:pageTitle', 'sort' => '-ga:pageviews', 'max-results' => $maxResults],
-        ];
-
-        $this->analyticsClient
-            ->shouldReceive('performQuery')->withArgs($expectedArguments)
-            ->once()
-            ->andReturn([
-                'rows' => [['https://test.com', 'Page title', '123']],
-            ]);
-
-        $response = $this->analytics->fetchMostVisitedPages(Period::create($this->startDate, $this->endDate), $maxResults);
-
-        $this->assertInstanceOf(Collection::class, $response);
-        $this->assertEquals('https://test.com', $response->first()['url']);
-        $this->assertEquals('Page title', $response->first()['pageTitle']);
-        $this->assertEquals(123, $response->first()['pageViews']);
-    }
-
-    /** @test */
-    public function it_can_fetch_the_top_referrers()
-    {
-        $maxResults = 10;
-
-        $expectedArguments = [
-            $this->viewId,
-            $this->expectCarbon($this->startDate),
-            $this->expectCarbon($this->endDate),
-            'ga:pageviews',
-            ['dimensions' => 'ga:fullReferrer', 'sort' => '-ga:pageviews', 'max-results' => $maxResults],
-        ];
-
-        $this->analyticsClient
-            ->shouldReceive('performQuery')->withArgs($expectedArguments)
-            ->once()
-            ->andReturn([
-                'rows' => [['https://referrer.com', '123']],
-            ]);
-
-        $response = $this->analytics->fetchTopReferrers(Period::create($this->startDate, $this->endDate), $maxResults);
-
-        $this->assertInstanceOf(Collection::class, $response);
-        $this->assertEquals('https://referrer.com', $response->first()['url']);
-        $this->assertEquals(123, $response->first()['pageViews']);
-    }
-
-    /** @test */
-    public function it_can_fetch_the_top_browsers()
-    {
-        $expectedArguments = [
-            $this->viewId,
-            $this->expectCarbon($this->startDate),
-            $this->expectCarbon($this->endDate),
-            'ga:sessions',
-            ['dimensions' => 'ga:browser', 'sort' => '-ga:sessions'],
-        ];
-
-        $this->analyticsClient
-            ->shouldReceive('performQuery')->withArgs($expectedArguments)
-            ->once()
-            ->andReturn([
-                'rows' => [
-                    ['Browser 1', '100'],
-                    ['Browser 2', '90'],
-                    ['Browser 3', '30'],
-                    ['Browser 4', '20'],
-                    ['Browser 1', '10'],
-                ],
-            ]);
-
-        $response = $this->analytics->fetchTopBrowsers(Period::create($this->startDate, $this->endDate), 3);
-
-        $this->assertInstanceOf(Collection::class, $response);
-        $this->assertEquals([
-            ['browser' => 'Browser 1', 'sessions' => 100],
-            ['browser' => 'Browser 2', 'sessions' => 90],
-            ['browser' => 'Others', 'sessions' => 60],
-        ], $response->toArray());
-    }
-
-    protected function expectCarbon(Carbon $carbon)
-    {
-        return Mockery::on(function (Carbon $argument) use ($carbon) {
-            return $argument->format('Y-m-d') == $carbon->format('Y-m-d');
-        });
-    }
+    return Mockery::on(function (Carbon $argument) use ($carbon) {
+        return $argument->format('Y-m-d') == $carbon->format('Y-m-d');
+    });
 }

--- a/tests/Unit/PeriodTest.php
+++ b/tests/Unit/PeriodTest.php
@@ -1,82 +1,61 @@
 <?php
 
-namespace Spatie\Analytics\Tests;
-
 use Carbon\Carbon;
-use DateTimeImmutable;
-use PHPUnit\Framework\TestCase;
-use Spatie\Analytics\Exceptions\InvalidPeriod;
 use Spatie\Analytics\Period;
+use Spatie\Analytics\Exceptions\InvalidPeriod;
 
-class PeriodTest extends TestCase
-{
-    /** @test */
-    public function it_can_create_a_period_for_a_given_amount_of_days()
-    {
-        Carbon::setTestNow(Carbon::create(2016, 1, 1));
+it('can_create_a_period_for_a_given_amount_of_days', function () {
+    Carbon::setTestNow(Carbon::create(2016, 1, 1));
 
-        $period = Period::days(10);
+    $period = Period::days(10);
 
-        $this->assertSame('2015-12-22', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
-    }
+    expect($period->startDate->format('Y-m-d'))->toBe('2015-12-22');
+    expect($period->endDate->format('Y-m-d'))->toBe('2016-01-01');
+});
 
-    /** @test */
-    public function it_can_create_a_period_for_a_given_amount_of_months()
-    {
-        Carbon::setTestNow(Carbon::create(2016, 1, 10));
+it('can_create_a_period_for_a_given_amount_of_months', function () {
+    Carbon::setTestNow(Carbon::create(2016, 1, 10));
 
-        $period = Period::months(10);
+    $period = Period::months(10);
 
-        $this->assertSame('2015-03-10', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-10', $period->endDate->format('Y-m-d'));
-    }
+    expect($period->startDate->format('Y-m-d'))->toBe('2015-03-10');
+    expect($period->endDate->format('Y-m-d'))->toBe('2016-01-10');
+});
 
-    /** @test */
-    public function it_can_create_a_period_for_a_given_amount_of_years()
-    {
-        Carbon::setTestNow(Carbon::create(2016, 1, 12));
+it('can_create_a_period_for_a_given_amount_of_years', function () {
+    Carbon::setTestNow(Carbon::create(2016, 1, 12));
 
-        $period = Period::years(2);
+    $period = Period::years(2);
 
-        $this->assertSame('2014-01-12', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-12', $period->endDate->format('Y-m-d'));
-    }
+    expect($period->startDate->format('Y-m-d'))->tobe('2014-01-12');
+    expect($period->endDate->format('Y-m-d'))->tobe('2016-01-12');
+});
 
-    /** @test */
-    public function it_provides_a_create_method()
-    {
-        $startDate = Carbon::create(2015, 12, 22);
-        $endDate = Carbon::create(2016, 1, 1);
+it('provides_a_create_method', function () {
+    $startDate = Carbon::create(2015, 12, 22);
+    $endDate = Carbon::create(2016, 1, 1);
 
-        $period = Period::create($startDate, $endDate);
+    $period = Period::create($startDate, $endDate);
 
-        $this->assertSame('2015-12-22', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
-    }
+    expect($period->startDate)->toBe($startDate);
+    expect($period->endDate)->toBe($endDate);
+});
 
-    /** @test */
-    public function it_accepts_datetime_immutable_instances()
-    {
-        $startDate = Carbon::create(2015, 12, 22)->toIso8601String();
-        $startDateImmutable = new DateTimeImmutable($startDate);
-        $endDate = Carbon::create(2016, 1, 1)->toIso8601String();
-        $endDateImmutable = new DateTimeImmutable($endDate);
+it('accepts_datetime_immutable_instances', function () {
+    $startDate = Carbon::create(2015, 12, 22)->toIso8601String();
+    $startDateImmutable = new DateTimeImmutable($startDate);
+    $endDate = Carbon::create(2016, 1, 1)->toIso8601String();
+    $endDateImmutable = new DateTimeImmutable($endDate);
 
-        $period = Period::create($startDateImmutable, $endDateImmutable);
+    $period = Period::create($startDateImmutable, $endDateImmutable);
 
-        $this->assertSame('2015-12-22', $period->startDate->format('Y-m-d'));
-        $this->assertSame('2016-01-01', $period->endDate->format('Y-m-d'));
-    }
+    expect($period->startDate->format('Y-m-d'))->toBe('2015-12-22');
+    expect($period->endDate->format('Y-m-d'))->toBe('2016-01-01');
+});
 
-    /** @test */
-    public function it_will_throw_an_exception_if_the_start_date_comes_after_the_end_date()
-    {
-        $startDate = Carbon::create(2016, 1, 1);
-        $endDate = Carbon::create(2015, 1, 1);
+it('will_throw_an_exception_if_the_start_date_comes_after_the_end_date', function () {
+    $startDate = Carbon::create(2016, 1, 1);
+    $endDate = Carbon::create(2015, 1, 1);
 
-        $this->expectException(InvalidPeriod::class);
-
-        Period::create($startDate, $endDate);
-    }
-}
+    Period::create($startDate, $endDate);
+})->throws(InvalidPeriod::class);


### PR DESCRIPTION
This Pull Request converts PHPUnit tests to PestPHP. It also refactors a few things like:

```php
 $this->app['config']->set('...');
```

**TO**

```php
config()->set('...');
```

Feel free to ask for any changes :)