### PR TITLE
Feature: Betterify Tests

### DIFF
--- a/tests/Unit/AnalyticsTest.php
+++ b/tests/Unit/AnalyticsTest.php
@@ -196,6 +196,6 @@ it('can_fetch_the_top_browsers', function () {
 function expectCarbon(Carbon $carbon)
 {
     return Mockery::on(function (Carbon $argument) use ($carbon) {
-        return $argument->format('Y-m-d') == $carbon->format('Y-m-d');
+        return $argument->format('Y-m-d') === $carbon->format('Y-m-d');
     });
 }

--- a/tests/Unit/PeriodTest.php
+++ b/tests/Unit/PeriodTest.php
@@ -5,30 +5,36 @@ use Spatie\Analytics\Exceptions\InvalidPeriod;
 use Spatie\Analytics\Period;
 
 it('can_create_a_period_for_a_given_amount_of_days', function () {
-    Carbon::setTestNow(Carbon::create(2016, 1, 1));
+    $expectedDate = Carbon::create(2016, 1, 1);
+    Carbon::setTestNow($expectedDate);
 
     $period = Period::days(10);
 
-    expect($period->startDate->format('Y-m-d'))->toBe('2015-12-22');
-    expect($period->endDate->format('Y-m-d'))->toBe('2016-01-01');
+    expect($period)
+        ->endDate->toEqual($expectedDate)
+        ->startDate->toEqual($expectedDate->subDays(10));
 });
 
 it('can_create_a_period_for_a_given_amount_of_months', function () {
-    Carbon::setTestNow(Carbon::create(2016, 1, 10));
+    $expectedDate = Carbon::create(2016, 1, 10);
+    Carbon::setTestNow($expectedDate);
 
     $period = Period::months(10);
 
-    expect($period->startDate->format('Y-m-d'))->toBe('2015-03-10');
-    expect($period->endDate->format('Y-m-d'))->toBe('2016-01-10');
+    expect($period)
+        ->endDate->toEqual($expectedDate)
+        ->startDate->toEqual($expectedDate->subMonths(10));
 });
 
 it('can_create_a_period_for_a_given_amount_of_years', function () {
-    Carbon::setTestNow(Carbon::create(2016, 1, 12));
+    $expectedDate = Carbon::create(2016, 1, 12);
+    Carbon::setTestNow($expectedDate);
 
     $period = Period::years(2);
 
-    expect($period->startDate->format('Y-m-d'))->tobe('2014-01-12');
-    expect($period->endDate->format('Y-m-d'))->tobe('2016-01-12');
+    expect($period)
+        ->endDate->toEqual($expectedDate)
+        ->startDate->toEqual($expectedDate->subYears(2));
 });
 
 it('provides_a_create_method', function () {
@@ -37,20 +43,23 @@ it('provides_a_create_method', function () {
 
     $period = Period::create($startDate, $endDate);
 
-    expect($period->startDate)->toBe($startDate);
-    expect($period->endDate)->toBe($endDate);
+    expect($period)
+        ->startDate->toBe($startDate)
+        ->endDate->toBe($endDate);
 });
 
 it('accepts_datetime_immutable_instances', function () {
-    $startDate = Carbon::create(2015, 12, 22)->toIso8601String();
-    $startDateImmutable = new DateTimeImmutable($startDate);
-    $endDate = Carbon::create(2016, 1, 1)->toIso8601String();
-    $endDateImmutable = new DateTimeImmutable($endDate);
+    $startDate = Carbon::create(2015, 12, 22);
+    $startDateImmutable = new DateTimeImmutable($startDate->toIso8601String());
+
+    $endDate = Carbon::create(2016, 1, 1);
+    $endDateImmutable = new DateTimeImmutable($endDate->toIso8601String());
 
     $period = Period::create($startDateImmutable, $endDateImmutable);
 
-    expect($period->startDate->format('Y-m-d'))->toBe('2015-12-22');
-    expect($period->endDate->format('Y-m-d'))->toBe('2016-01-01');
+    expect($period)
+        ->startDate->toEqual($startDate)
+        ->endDate->toEqual($endDate);
 });
 
 it('will_throw_an_exception_if_the_start_date_comes_after_the_end_date', function () {


### PR DESCRIPTION
Hi👋
This PR improves some tests by replacing expectations on hardcoded dates with Carbon instances. 

**Example**
**From this:**

```php
Carbon::setTestNow(Carbon::create(2016, 1, 1));

$period = Period::days(10);

expect($period->startDate->format('Y-m-d'))->toBe('2015-12-22');
expect($period->endDate->format('Y-m-d'))->toBe('2016-01-01');
```

**To This:**

```php
$expectedDate = Carbon::create(2016, 1, 1);
Carbon::setTestNow($expectedDate);

$period = Period::days(10);

expect($period)
    ->endDate->toEqual($expectedDate)
    ->startDate->toEqual($expectedDate->subDays(10));
```

Plus, also refactors to possibly use higher-order expectations. 

