### PR TITLE
Add PHP 8.2 Tests Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,13 +35,14 @@ jobs:
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                     coverage: none
 
+
+            -   name: Setup Composer Pest Plugin
+                run: composer config --no-plugins allow-plugins.pestphp/pest-plugin true
+
             -   name: Install dependencies
                 run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-
-            -   name: Setup Composer Pest Plugin
-                run: composer config --no-plugins allow-plugins.pestphp/pest-plugin true
 
             -   name: Execute tests
                 run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0]
+                php: [8.2, 8.1, 8.0]
                 laravel: [9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -20,10 +20,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -   name: Cache dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ~/.composer/cache/files
                     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -39,5 +39,6 @@ jobs:
                 run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
             -   name: Execute tests
                 run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,5 +40,8 @@ jobs:
                     composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
+            -   name: Setup Composer Pest Plugin
+                run: composer config --no-plugins allow-plugins.pestphp/pest-plugin true
+
             -   name: Execute tests
                 run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,18 @@
     ],
     "require": {
         "php": "^8.0",
-        "google/apiclient": "^2.7",
-        "laravel/framework": "^9.0",
-        "nesbot/carbon": "^2.0",
-        "spatie/laravel-package-tools": "^1.9",
-        "symfony/cache": "^6.0"
+        "google/apiclient": "^2.12.6",
+        "laravel/framework": "^9.41",
+        "nesbot/carbon": "^2.63",
+        "spatie/laravel-package-tools": "^1.13.7",
+        "symfony/cache": "^6.1"
     },
     "require-dev": {
-        "league/flysystem": "^2.0|^3.0",
-        "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^7.0",
-        "pestphp/pest": "^1.21",
-        "phpunit/phpunit": "^9.4"
+        "league/flysystem": "^2.0|^3.10.3",
+        "mockery/mockery": "^1.5.1",
+        "orchestra/testbench": "^7.14",
+        "pestphp/pest": "^1.22.2",
+        "phpunit/phpunit": "^9.5.26"
     },
     "autoload": {
         "psr-4": {
@@ -55,7 +55,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
         "laravel/framework": "^9.41",
         "nesbot/carbon": "^2.63",
         "spatie/laravel-package-tools": "^1.13.7",
-        "symfony/cache": "^6.1"
+        "symfony/cache": "^6.0"
     },
     "require-dev": {
-        "league/flysystem": "^2.0|^3.10.3",
-        "mockery/mockery": "^1.5.1",
-        "orchestra/testbench": "^7.14",
+        "league/flysystem": "^2.0|^3.0",
+        "mockery/mockery": "^1.5",
+        "orchestra/testbench": "^7.0",
         "pestphp/pest": "^1.22.2",
-        "phpunit/phpunit": "^9.5.26"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds PHP 8.2 support to the GitHub tests workflow, as well as upgrades the `actions/checkout` and `actions/cache` actions to latest versions.

It also bumps several dependency versions, including `nesbot/carbon`, which was required for 8.2 support.