### PR TITLE
DimensionFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ $orderBy = [
 ];
 ```
 
-`FilterExpression $dimensionFilter`: filter the result to include only specific dimension values. You can find more details [here](https://cloud.google.com/php/docs/reference/analytics-data/latest/V1beta.RunReportRequest#_Google_Analytics_Data_V1beta_RunReportRequest__setDimensionFilter__).
+`FilterExpression $dimensionFilter`: filter the result to include only specific dimension values. You can find more details [here](https://cloud.google.com/php/docs/reference/analytics-data/latest/V1beta.RunReportRequest).
 
 For example:
 ```php

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The function returns a `Collection` in which each item is an array that holds ke
 For all other queries you can use the `get` function.
 
 ```php
-public function get(Period $period, array $metrics, array $dimensions = [], int $limit = 10, array $orderBy = []): Collection
+public function get(Period $period, array $metrics, array $dimensions = [], int $limit = 10, array $orderBy = [], FilterExpression $dimensionFilter = null): Collection
 ```
 
 Here's some extra info on the arguments you can pass:
@@ -252,6 +252,26 @@ $orderBy = [
     OrderBy::dimension('date', true),
     OrderBy::metric('pageViews', false),
 ];
+```
+
+`FilterExpression $dimensionFilter`: filter the result to include only specific dimension values. You can find more details [here](https://cloud.google.com/php/docs/reference/analytics-data/latest/V1beta.RunReportRequest#_Google_Analytics_Data_V1beta_RunReportRequest__setDimensionFilter__).
+
+For example:
+```php
+use Google\Analytics\Data\V1beta\Filter;
+use Google\Analytics\Data\V1beta\FilterExpression;
+use Google\Analytics\Data\V1beta\Filter\StringFilter;
+use Google\Analytics\Data\V1beta\Filter\StringFilter\MatchType;
+
+$dimensionFilter = new FilterExpression ([
+    'filter' => new Filter([
+        'field_name' => 'eventName',
+        'string_filter' => new StringFilter ([
+            'match_type' => MatchType::EXACT,
+            'value' => 'click',
+        ]),
+    ]),    
+]);
 ```
 
 ## Testing

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Analytics;
 
+use Google\Analytics\Data\V1beta\FilterExpression;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 
@@ -171,6 +172,7 @@ class Analytics
         array $dimensions = [],
         int $maxResults = 10,
         array $orderBy = [],
+        FilterExpression $dimensionFilter = null,
     ): Collection {
         return $this->client->get(
             $this->propertyId,
@@ -179,6 +181,7 @@ class Analytics
             $dimensions,
             $maxResults,
             $orderBy,
+            $dimensionFilter,
         );
     }
 }

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -4,6 +4,7 @@ namespace Spatie\Analytics;
 
 use Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
 use Google\Analytics\Data\V1beta\Dimension;
+use Google\Analytics\Data\V1beta\FilterExpression;
 use Google\Analytics\Data\V1beta\Metric;
 use Google\Analytics\Data\V1beta\RunReportResponse;
 use Illuminate\Contracts\Cache\Repository;
@@ -33,6 +34,7 @@ class AnalyticsClient
         array $dimensions = [],
         int $maxResults = 10,
         array $orderBy = [],
+        FilterExpression $dimensionFilter = null,
     ): Collection {
         $typeCaster = resolve(TypeCaster::class);
 
@@ -45,6 +47,7 @@ class AnalyticsClient
             'dimensions' => $this->getFormattedDimensions($dimensions),
             'limit' => $maxResults,
             'orderBys' => $orderBy,
+            'dimensionFilter' => $dimensionFilter,
         ]);
 
         $result = collect();


### PR DESCRIPTION
Hello,
I would like to use the runReport method of BetaAnalyticsDataClient with the [dimension_filter ](https://cloud.google.com/php/docs/reference/analytics-data/latest/V1beta.RunReportRequest) parameter. I extended the [get](https://github.com/spatie/laravel-analytics#all-other-google-analytics-queries) method of laravel-analytics with this optional argument.