### PR TITLE
Extend Analytics::get with dimensionFilter parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The function returns a `Collection` in which each item is an array that holds ke
 For all other queries you can use the `get` function.
 
 ```php
-public function get(Period $period, array $metrics, array $dimensions = [], int $limit = 10, array $orderBy = []): Collection
+public function get(Period $period, array $metrics, array $dimensions = [], int $limit = 10, array $orderBy = [], FilterExpression $dimensionFilter = null): Collection
 ```
 
 Here's some extra info on the arguments you can pass:
@@ -244,6 +244,26 @@ $orderBy = [
     OrderBy::dimension('date', true),
     OrderBy::metric('pageViews', false),
 ];
+```
+
+`FilterExpression $dimensionFilter`: filter the result to include only specific dimension values. You can find more details [here](https://cloud.google.com/php/docs/reference/analytics-data/latest/V1beta.RunReportRequest).
+
+For example:
+```php
+use Google\Analytics\Data\V1beta\Filter;
+use Google\Analytics\Data\V1beta\FilterExpression;
+use Google\Analytics\Data\V1beta\Filter\StringFilter;
+use Google\Analytics\Data\V1beta\Filter\StringFilter\MatchType;
+
+$dimensionFilter = new FilterExpression ([
+    'filter' => new Filter([
+        'field_name' => 'eventName',
+        'string_filter' => new StringFilter ([
+            'match_type' => MatchType::EXACT,
+            'value' => 'click',
+        ]),
+    ]),    
+]);
 ```
 
 ## Testing

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Analytics;
 
+use Google\Analytics\Data\V1beta\FilterExpression;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 
@@ -178,6 +179,7 @@ class Analytics
         int $maxResults = 10,
         array $orderBy = [],
         int $offset = 0,
+        FilterExpression $dimensionFilter = null,
     ): Collection {
         return $this->client->get(
             $this->propertyId,
@@ -187,6 +189,7 @@ class Analytics
             $maxResults,
             $orderBy,
             $offset,
+            $dimensionFilter,
         );
     }
 }

--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -4,6 +4,7 @@ namespace Spatie\Analytics;
 
 use Google\Analytics\Data\V1beta\BetaAnalyticsDataClient;
 use Google\Analytics\Data\V1beta\Dimension;
+use Google\Analytics\Data\V1beta\FilterExpression;
 use Google\Analytics\Data\V1beta\Metric;
 use Google\Analytics\Data\V1beta\RunReportResponse;
 use Illuminate\Contracts\Cache\Repository;
@@ -34,6 +35,7 @@ class AnalyticsClient
         int $maxResults = 10,
         array $orderBy = [],
         int $offset = 0,
+        FilterExpression $dimensionFilter = null,
     ): Collection {
         $typeCaster = resolve(TypeCaster::class);
 
@@ -47,6 +49,7 @@ class AnalyticsClient
             'limit' => $maxResults,
             'offset' => $offset,
             'orderBys' => $orderBy,
+            'dimensionFilter' => $dimensionFilter,
         ]);
 
         $result = collect();

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -32,6 +32,7 @@ it('can fetch the visitor and page views', function () {
         10,
         [],
         0,
+        null,
     ];
 
     $this
@@ -70,6 +71,7 @@ it('can fetch the visitor and page views by date', function () {
             OrderBy::dimension('date', true),
         ],
         0,
+        null,
     ];
 
     $this
@@ -110,6 +112,7 @@ it('can fetch the total visitor and page views', function () {
             OrderBy::dimension('date', true),
         ],
         0,
+        null,
     ];
 
     $this
@@ -151,6 +154,7 @@ it('can fetch the most visited pages', function () {
             OrderBy::metric('screenPageViews', true),
         ],
         0,
+        null,
     ];
 
     $this
@@ -193,6 +197,7 @@ it('can fetch the top referrers', function () {
             OrderBy::metric('screenPageViews', true),
         ],
         0,
+        null,
     ];
 
     $this
@@ -231,6 +236,7 @@ it('can fetch the top browsers', function () {
             OrderBy::metric('screenPageViews', true),
         ],
         0,
+        null,
     ];
 
     $this


### PR DESCRIPTION
Hello,
I would like to use the runReport method of BetaAnalyticsDataClient with the [dimension_filter ](https://cloud.google.com/php/docs/reference/analytics-data/latest/V1beta.RunReportRequest)parameter. I extended the [get](https://github.com/spatie/laravel-analytics#all-other-google-analytics-queries) method of laravel-analytics with this optional argument.