### PR TITLE
Updated example env value key in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ return [
     /*
      * The property id of which you want to display data.
      */
-    'property_id' => env('PROPERTY_ID'),
+    'property_id' => env('ANALYTICS_PROPERTY_ID'),
 
     /*
      * Path to the client secret json file. Take a look at the README of this package


### PR DESCRIPTION
In current README.md file mentioned "PROPERTY_ID" to access the id of google analytics from ENV file, but actully getting ANALYTICS_PROPERTY_ID instead. I hope correcting the property will help without publish the stub.