### PR TITLE
Allow Carbon 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "google/analytics-data": "^0.9.4",
         "laravel/framework": "^10.0|^11.0",
-        "nesbot/carbon": "^2.66",
+        "nesbot/carbon": "^2.66|^3.00",
         "spatie/laravel-package-tools": "^1.13.7",
         "symfony/cache": "^6.0|^7.0"
     },

--- a/src/Period.php
+++ b/src/Period.php
@@ -6,9 +6,12 @@ use Carbon\Carbon;
 use DateTimeInterface;
 use Google\Analytics\Data\V1beta\DateRange;
 use Spatie\Analytics\Exceptions\InvalidPeriod;
+use Illuminate\Support\Traits\Macroable;
 
 class Period
 {
+    use Macroable;
+
     public DateTimeInterface $startDate;
 
     public DateTimeInterface $endDate;


### PR DESCRIPTION
Carbon 2 & 3 works, but Laravel 11 install Carbon 3 by default.

References:

- https://laravel.com/docs/11.x/upgrade#carbon-3
- https://github.com/laravel/framework/blob/11.x/composer.json#L39