### PR TITLE
Ability to run realtime reports from GA4

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -228,4 +228,29 @@ class Analytics
             $metricFilter
         );
     }
+    
+    public function getRealtime(
+        Period $period,
+        array $metrics,
+        array $dimensions = [],
+        int $maxResults = 10,
+        array $orderBy = [],
+        int $offset = 0,
+        ?FilterExpression $dimensionFilter = null,
+        bool $keepEmptyRows = false,
+        ?FilterExpression $metricFilter = null,
+    ): Collection {
+        return $this->client->getRealtime(
+            $this->propertyId,
+            $period,
+            $metrics,
+            $dimensions,
+            $maxResults,
+            $orderBy,
+            $offset,
+            $dimensionFilter,
+            $keepEmptyRows,
+            $metricFilter
+        );
+    }
 }


### PR DESCRIPTION
This pull request extends the functionality to enable running real-time reports from GA4.

For instance, it allows retrieving the number of active users in the last 30 minutes.


```
use Spatie\Analytics\Facades\Analytics;
use Spatie\Analytics\Period;

// number of active users in the last 30 minutes which is visible in GA4 -> reports -> realtime overview
$period = Period::create(Carbon::today(), Carbon::today());
Analytics::getRealtime(period: $period, metrics: ['activeUsers']);
```