### PR TITLE
Update `googleapis/php-analytics-data` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "google/analytics-data": "^0.9.4",
+        "google/analytics-data": "^0.21.1",
         "laravel/framework": "^10.0|^11.0",
         "nesbot/carbon": "^2.66|^3.1.0",
         "spatie/laravel-package-tools": "^1.13.7",


### PR DESCRIPTION
Hi,

We received the following email from Google regarding upcoming changes to the way empty data fields are handled...

```text
[Action Required] Google Analytics Data API empty field changes

Hello Google Analytics user,

You’re receiving this message because you’re an owner of a Google Cloud Platform (GCP) project that might be affected by the upcoming change in the Google Analytics Data API.

The Google Analytics Data API is changing the way empty fields are treated in reports.

Today, for fields where Google Analytics doesn’t receive any data, the value (not set) is returned in a report. The Google Analytics Data API will return blank values instead of (not set), beginning in March 2025.

Action Required:

Google Analytics Data API users that are pulling reporting data with filters comparing against the (not set) value will need to update their filtering conditions to compare against a blank value using the [EmptyFilter](https://notifications.google.com/g/p/ANiao5ouxOBRK-eggh3lHHtkrYwj-YXtiMJO_JBCaohhpcm_5ZKYBe4QBkdUPLlVzLx6dUykQ4YRGEiAaBk3LnAZxzRw8NyMd_Nn6MvkXFqkw87Bg-dZN0ZUoDgnZtQ4WxYMMKsOqtplHdKp7l5dvP8RD0ENWRidAbZlBzzekxBoj6z29O9PnK6Iiv5APXnbid9r8vH3CX-sKDfyNWJawqFCg8QJk87xvG107mzYQOVdJhglhUgTAucNdMrqvlRnHQNJfQLV0O85sTBOJHXHlBm4j9H_BeIrpTGZag) filter type.
If you don’t take action, your reports may show incorrect or empty results.

Sincerely,

The Google Analytics Team
```

In essence, what this means is, whereas before you may have done something like this...

```php
$dimensionFilter = new FilterExpression([
    'filter' => new Filter([
        'field_name' => 'city',
        'string_filter' => new StringFilter([
            'match_type' => MatchType::EXACT,
            'value' => '(not set)',
        ]),
    ]),    
]);
```
You would now need to do this...
```php
$dimensionFilter = new FilterExpression([
    'filter' => new Filter([
        'field_name' => 'city',
        'empty_filter' => new EmptyFilter(),
    ]),    
]);
```

The `EmptyFilter` was added in [v0.21.01](https://github.com/googleapis/php-analytics-data/releases/tag/v0.21.1) hence this PR bumps the minimum version required.

Thanks