### PR TITLE
Fix TypeError in runRealtimeReport after upgrading

### DIFF
--- a/src/AnalyticsClient.php
+++ b/src/AnalyticsClient.php
@@ -95,16 +95,14 @@ class AnalyticsClient
 
         $response = $this->runRealtimeReport([
             'property' => "properties/{$propertyId}",
-            'date_ranges' => [
-                $period->toDateRange(),
+            'minute_ranges' => [
+                $period->toMinuteRange(),
             ],
             'metrics' => $this->getFormattedMetrics($metrics),
             'dimensions' => $this->getFormattedDimensions($dimensions),
             'limit' => $maxResults,
-            'offset' => $offset,
             'order_bys' => $orderBy,
             'dimension_filter' => $dimensionFilter,
-            'keep_empty_rows' => $keepEmptyRows,
             'metric_filter' => $metricFilter,
         ]);
 

--- a/src/Period.php
+++ b/src/Period.php
@@ -5,6 +5,7 @@ namespace Spatie\Analytics;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Google\Analytics\Data\V1beta\DateRange;
+use Google\Analytics\Data\V1beta\MinuteRange;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\Analytics\Exceptions\InvalidPeriod;
 
@@ -64,5 +65,12 @@ class Period
         return (new DateRange)
             ->setStartDate($this->startDate->format('Y-m-d'))
             ->setEndDate($this->endDate->format('Y-m-d'));
+    }
+
+    public function toMinuteRange(): MinuteRange
+    {
+        return (new MinuteRange)
+            ->setStartMinutesAgo($this->endDate->diff($this->startDate)->i)
+            ->setEndMinutesAgo($this->endDate->format('i'));
     }
 }


### PR DESCRIPTION
This PR fixes a TypeError that occurs after upgrading to propably version 5.5.2 (reference to PR https://github.com/spatie/laravel-analytics/pull/535).

When calling runRealtimeReport(), the method expects an argument of type Google\Analytics\Data\V1beta\RunRealtimeReportResponse, but an array is being passed instead. This results in the following error:

TypeError: Spatie\Analytics\AnalyticsClient::runRealtimeReport(): Return value must be of type Google\Analytics\Data\V1beta\RunRealtimeReportResponse, Google\Analytics\Data\V1beta\RunReportResponse returned, array given (reference: https://github.com/spatie/laravel-analytics/discussions/515#discussioncomment-12513091)

This fix will ensure that the request argument passed to runRealtimeReport() is correctly instantiated instantiated and that the time range is adjusted, as using a date range is no longer possible in real-time reports.

```php
use Spatie\Analytics\Facades\Analytics;
use Spatie\Analytics\Period;

// number of active users in the last 30 minutes which is visible in GA4 -> reports -> realtime overview
$period = Period::create(Carbon::now()->subMinutes(29), Carbon::now());
Analytics::getRealtime(period: $period, metrics: ['activeUsers']);
``` 